### PR TITLE
Add bulk indexing support

### DIFF
--- a/src/Contracts/ElasticsearchServiceContract.php
+++ b/src/Contracts/ElasticsearchServiceContract.php
@@ -21,6 +21,13 @@ interface ElasticsearchServiceContract
      */
     public function index(array $params = []);
 
+    /**
+     * @param array $params
+     *
+     * @return array
+     */
+    public function bulk(array $params = []);
+
 
     /**
      * @param array $params

--- a/src/ElasticsearchService.php
+++ b/src/ElasticsearchService.php
@@ -59,6 +59,15 @@ class ElasticsearchService implements ElasticsearchServiceContract
     /**
      * @inheritdoc
      */
+    public function bulk(array $params = [])
+    {
+        return $this->client->bulk($params);
+    }
+
+
+    /**
+     * @inheritdoc
+     */
     public function delete(array $params = [])
     {
         return $this->client->delete($params);

--- a/src/Queries/Bulk/AbstractBulkQuery.php
+++ b/src/Queries/Bulk/AbstractBulkQuery.php
@@ -1,0 +1,9 @@
+<?php namespace Nord\Lumen\Elasticsearch\Queries\Bulk;
+
+/**
+ * Class AbstractBulkQuery
+ */
+abstract class AbstractBulkQuery extends \Nord\Lumen\Elasticsearch\Queries\QueryDSL
+{
+
+}

--- a/src/Queries/Bulk/BulkAction.php
+++ b/src/Queries/Bulk/BulkAction.php
@@ -1,0 +1,74 @@
+<?php namespace Nord\Lumen\Elasticsearch\Queries\Bulk;
+
+class BulkAction
+{
+
+    const ACTION_INDEX = 'index';
+
+    /**
+     * @var string
+     */
+    private $action;
+
+    /**
+     * @var array
+     */
+    private $metadata;
+
+    /**
+     * @var array
+     */
+    private $body;
+
+
+    /**
+     * @return string
+     */
+    public function getAction()
+    {
+        return $this->action;
+    }
+
+
+    /**
+     * @param string $action
+     * @param array  $metadata
+     */
+    public function setAction($action, $metadata)
+    {
+        $this->action   = $action;
+        $this->metadata = $metadata;
+
+        return $this;
+    }
+
+
+    /**
+     * @return array
+     */
+    public function getMetadata()
+    {
+        return $this->metadata;
+    }
+    
+
+    /**
+     * @return array
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+
+    /**
+     * @param array $body
+     */
+    public function setBody($body)
+    {
+        $this->body = $body;
+
+        return $this;
+    }
+
+}

--- a/src/Queries/Bulk/BulkQuery.php
+++ b/src/Queries/Bulk/BulkQuery.php
@@ -1,0 +1,92 @@
+<?php namespace Nord\Lumen\Elasticsearch\Queries\Bulk;
+
+class BulkQuery extends AbstractBulkQuery
+{
+
+    /**
+     * The number of actions to handle in one query
+     */
+    const BULK_SIZE_DEFAULT = 500;
+
+    /**
+     * @var BulkAction[]
+     */
+    private $actions;
+
+    /**
+     * @var int
+     */
+    private $bulkSize;
+
+
+    /**
+     * BulkQuery constructor.
+     *
+     * @param int $bulkSize
+     */
+    public function __construct($bulkSize)
+    {
+        $this->bulkSize = $bulkSize;
+    }
+
+
+    /**
+     * @param BulkAction $action
+     *
+     * @return BulkQuery
+     */
+    public function addAction(BulkAction $action)
+    {
+        $this->actions[] = $action;
+
+        return $this;
+    }
+
+
+    /**
+     * @return bool
+     */
+    public function hasItems()
+    {
+        return !empty($this->actions);
+    }
+
+
+    /**
+     * @return bool whether the query is ready for dispatch
+     */
+    public function isReady()
+    {
+        return count($this->actions) === $this->bulkSize;
+    }
+
+
+    /**
+     * Removes all actions
+     */
+    public function reset()
+    {
+        $this->actions = [];
+    }
+
+
+    /**
+     * @inheritdoc
+     */
+    public function toArray()
+    {
+        $result = [
+            'body' => [],
+        ];
+
+        foreach ($this->actions as $action) {
+            $result['body'][] = [
+                $action->getAction() => $action->getMetadata(),
+                $action->getBody(),
+            ];
+        }
+
+        return $result;
+    }
+
+}

--- a/tests/unit/BulkQueryTest.php
+++ b/tests/unit/BulkQueryTest.php
@@ -49,7 +49,9 @@ class BulkQueryTest extends \Codeception\TestCase\Test
     public function testSerialization()
     {
         $this->specify('checking serialization', function () {
-            $index = [
+            $actionName = \Nord\Lumen\Elasticsearch\Queries\Bulk\BulkAction::ACTION_INDEX;
+
+            $metadata = [
                 '_index' => 'foo',
                 '_type'  => 'bar',
                 '_id'    => 'baz',
@@ -61,20 +63,19 @@ class BulkQueryTest extends \Codeception\TestCase\Test
 
             // Add two actions (same item twice)
             $action = new \Nord\Lumen\Elasticsearch\Queries\Bulk\BulkAction();
-            $action->setAction(\Nord\Lumen\Elasticsearch\Queries\Bulk\BulkAction::ACTION_INDEX, $index)
-                   ->setBody($body);
+            $action->setAction($actionName, $metadata)->setBody($body);
 
             $this->query->addAction($action)->addAction($action);
 
             verify($this->query->toArray())->equals([
                 'body' => [
                     [
-                        'index' => $index,
+                        $actionName => $metadata,
                         $body,
                     ],
 
                     [
-                        'index' => $index,
+                        $actionName => $metadata,
                         $body,
                     ],
 


### PR DESCRIPTION
Fixes #5 

Changes proposed in this pull request:
 * expose the `bulk()` method through the service contract
 * use bulk indexing in `IndexCommand`. It is highly likely that console commands like this are used precisely to populate a cold index so the performance gains should be substantial.
 * the bulk size is 500 by default and can be overridden by subclasses

Before:

```
$ time php artisan index
Indexing data ...
 2351/2351 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
Done!

real	0m18.504s
user	0m7.592s
sys	0m0.940s
```

After:

```
$ time php artisan index
Indexing data ...
 2351/2351 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%
Done!

real	0m5.935s
user	0m4.164s
sys	0m0.472s
```